### PR TITLE
Setup mix task

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,12 +13,26 @@ The package can be installed by adding `foreperson` to your list of dependencies
 ```elixir
 def deps do
   [
-    {:foreperson, "~> 0.1.0", only: [:dev, :test]}
+    {:foreperson, "~> 0.1", only: [:dev, :test]}
   ]
 end
 ```
 
 See the [`Foreperson`](https://hexdocs.pm/foreperson/Foreperson.html#content) module doc for configuration options.
+
+### Running in seperate process or shell
+
+By default, Foreperson will run under your applications main supervisor.  However, can run it in it's own process in a different shell.
+
+Set runtime to false in your `mix.exs` deps
+```
+{:foreperson, "~> 0.1", only: [:dev, :test], runtime: false}
+```
+
+Then start it via the mix task
+```
+$ mix foreperson.start
+```
 
 ### Why?
 

--- a/lib/mix/tasks/foreperson.start.ex
+++ b/lib/mix/tasks/foreperson.start.ex
@@ -1,0 +1,18 @@
+defmodule Mix.Tasks.Foreperson.Start do
+  use Mix.Task
+
+  @shortdoc "Starts all configured Foreperson processes."
+
+  @moduledoc """
+  #{@shortdoc}
+
+    $ mix foreperson.start
+  """
+
+  @impl true
+  @doc false
+  def run(_) do
+    :ok = Application.start(:foreperson)
+    Process.sleep(:infinity)
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -5,7 +5,7 @@ defmodule Foreperson.MixProject do
     [
       app: :foreperson,
       name: "foreperson",
-      version: "0.1.1",
+      version: "0.1.2",
       elixir: "~> 1.11",
       start_permanent: Mix.env() == :prod,
       description: "Process runner for external dependencies in local dev environments",


### PR DESCRIPTION
Sets up a mix task so you can run the configured processes outside of your main applications supervisor tree.